### PR TITLE
chore(update): org.gnome.Platform 41

### DIFF
--- a/org.gnome.gThumb.yml
+++ b/org.gnome.gThumb.yml
@@ -1,6 +1,6 @@
 app-id: org.gnome.gThumb
 runtime: org.gnome.Platform
-runtime-version: '40'
+runtime-version: '41'
 sdk: org.gnome.Sdk
 
 command: gthumb


### PR DESCRIPTION
Update to latest and greatest GNOME runtime. Tested this build locally and LGTM so far.