### PR TITLE
Add JPEG XL support

### DIFF
--- a/org.gnome.gThumb.yml
+++ b/org.gnome.gThumb.yml
@@ -20,12 +20,15 @@ finish-args:
   - --filesystem=xdg-run/gvfsd
   - --talk-name=org.gtk.vfs.*
 
+cleanup:
+  - /include
+  - "*.a"
+  - "*.la"
 
 modules:
   - name: exiv2
     buildsystem: cmake-ninja
     cleanup:
-      - /include
       - /lib/exiv2
       - /share/man
     config-opts:
@@ -55,8 +58,6 @@ modules:
       - type: archive
         url: https://www.freedesktop.org/software/colord/releases/colord-1.3.5.tar.xz
         sha256: 2daa8ffd2a532d7094927cd1a4af595b8310cea66f7707edcf6ab743460feed2
-    cleanup:
-      - /include
 
   # adapted from https://github.com/flathub/org.free_astro.siril/blob/master/org.free_astro.siril.json#L257-L282
   - name: libheif
@@ -64,7 +65,6 @@ modules:
       - "--disable-gdk-pixbuf"
     cleanup:
       - "/bin"
-      - "/include"
       - "/share/man"
     modules:
       - name: libde265
@@ -72,7 +72,6 @@ modules:
           - "--disable-sherlock265"
         cleanup:
           - "/bin"
-          - "/include"
         sources:
           - type: archive
             url: https://github.com/strukturag/libde265/releases/download/v1.0.8/libde265-1.0.8.tar.gz
@@ -89,14 +88,11 @@ modules:
       - -DBUILD_TESTING=OFF
     cleanup:
       - /bin
-      - /include
     modules:
       - name: highway
         buildsystem: cmake
         config-opts:
           - -DBUILD_TESTING=OFF
-        cleanup:
-          - /include
         sources:
           - type: archive
             url: https://github.com/google/highway/archive/refs/tags/0.15.0.tar.gz
@@ -118,7 +114,6 @@ modules:
         commands:
           - autoreconf -fi
     cleanup:
-      - /include
       - /share/doc
 
   - name: totem-pl-parser
@@ -127,8 +122,6 @@ modules:
       - type: archive
         url: https://download.gnome.org/sources/totem-pl-parser/3.26/totem-pl-parser-3.26.6.tar.xz
         sha256: c0df0f68d5cf9d7da43c81c7f13f11158358368f98c22d47722f3bd04bd3ac1c
-    cleanup:
-      - /include
 
   - name: totem-video-thumbnailer
     buildsystem: meson
@@ -146,6 +139,5 @@ modules:
       - type: patch
         path: gthumb-update-release.patch
     cleanup:
-      - /include
       - /share/aclocal
 

--- a/org.gnome.gThumb.yml
+++ b/org.gnome.gThumb.yml
@@ -72,6 +72,7 @@ modules:
           - "--disable-sherlock265"
         cleanup:
           - "/bin"
+          - "/include"
         sources:
           - type: archive
             url: https://github.com/strukturag/libde265/releases/download/v1.0.8/libde265-1.0.8.tar.gz
@@ -80,6 +81,31 @@ modules:
       - url: https://github.com/strukturag/libheif/releases/download/v1.12.0/libheif-1.12.0.tar.gz
         sha256: e1ac2abb354fdc8ccdca71363ebad7503ad731c84022cf460837f0839e171718
         type: archive
+
+  - name: libjxl
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DBUILD_TESTING=OFF
+    cleanup:
+      - /bin
+      - /include
+    modules:
+      - name: highway
+        buildsystem: cmake
+        config-opts:
+          - -DBUILD_TESTING=OFF
+        cleanup:
+          - /include
+        sources:
+          - type: archive
+            url: https://github.com/google/highway/archive/refs/tags/0.15.0.tar.gz
+            sha256: 4bbd4439eae08cf038f1c5cc5d9ebc6a1a50f2c610c13a1483adccacfa24c150
+    # Using git because it downloads automatically some build dependencies as submodules.
+    sources:
+      - type: git
+        url: https://github.com/libjxl/libjxl.git
+        tag: v0.6.1
 
   - name: libraw
     config-opts:


### PR DESCRIPTION
Fix #4 

The build is failing on my computer while building the highway module and I can't understand why. It seems a DNS failure:

```
-- Build files have been written to: /run/build/highway/googletest-download
[ 11%] Creating directories for 'googletest'
[ 22%] Performing download step (git clone) for 'googletest'
Cloning into 'googletest-src'...
fatal: unable to access 'https://github.com/google/googletest.git/': Could not resolve host: github.com
Cloning into 'googletest-src'...
fatal: unable to access 'https://github.com/google/googletest.git/': Could not resolve host: github.com
Cloning into 'googletest-src'...
fatal: unable to access 'https://github.com/google/googletest.git/': Could not resolve host: github.com
-- Had to git clone more than once:
          3 times.
CMake Error at googletest-download/googletest-prefix/tmp/googletest-gitclone.cmake:31 (message):
  Failed to clone repository: 'https://github.com/google/googletest.git'


make[2]: *** [CMakeFiles/googletest.dir/build.make:99: googletest-prefix/src/googletest-stamp/googletest-download] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/googletest.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
CMake Error at CMakeLists.txt:316 (message):
  Build step for googletest failed: 2
```

or maybe the fact that there's no master branch? Default branch is main.
I'd rather disable googletest, if possible.